### PR TITLE
Fix crash on Driver Properties -> Registry -> Jump To Key

### DIFF
--- a/Source/WinObjEx64/props/propDriverConsts.h
+++ b/Source/WinObjEx64/props/propDriverConsts.h
@@ -20,4 +20,4 @@
 
 #define REGEDITWNDCLASS           L"RegEdit_RegEdit"
 #define PROPDRVREGSERVICESKEY     L"\\HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\%ws"
-#define PROPDRVREGSERVICESKEYLEN  sizeof(REGISTRYSERVICESKEY) - sizeof(WCHAR)
+#define PROPDRVREGSERVICESKEYLEN  sizeof(PROPDRVREGSERVICESKEY) - sizeof(WCHAR)


### PR DESCRIPTION
wsprintf on registry key (https://github.com/hfiref0x/WinObjEx64/blame/9245836619bae5baa1a7da3edf5ade03dda1d659/Source/WinObjEx64/props/propDriver.c#L433) was causing memory corruption which led to crash or instability of the program because of incorrect allocation of registry key path string