### PR TITLE
Fix: job always shows only one process in the list

### DIFF
--- a/Source/WinObjEx64/props/propBasic.c
+++ b/Source/WinObjEx64/props/propBasic.c
@@ -1219,7 +1219,7 @@ VOID propBasicQueryJob(
                 bytesNeeded,
                 &bytesNeeded);
 
-            if (status == STATUS_BUFFER_TOO_SMALL) {
+            if (status == STATUS_BUFFER_OVERFLOW) {
 
                 supVirtualFree(pJobProcList);
                 pJobProcList = supVirtualAlloc(bytesNeeded);


### PR DESCRIPTION
Job object properties page has a combobox that is intended to list all the processes in the job. However, it always shows only one process. That's because `NtQueryInformationJobObject` returns unexpected status code when the buffer is too small.