### PR TITLE
Fix type of ObjectHeader.PointerCount

### DIFF
--- a/Source/WinObjEx64/ntos/ntos.h
+++ b/Source/WinObjEx64/ntos/ntos.h
@@ -3190,7 +3190,7 @@ typedef struct _OBJECT_TYPE_RS2 {
 */
 
 typedef struct _OBJECT_HEADER {
-    LONG PointerCount;
+    LONG_PTR PointerCount;
     union
     {
         LONG HandleCount;

--- a/Source/WinObjEx64/props/propBasic.c
+++ b/Source/WinObjEx64/props/propBasic.c
@@ -1427,7 +1427,7 @@ VOID propSetBasicInfoEx(
 
     //Reference Count
     RtlSecureZeroMemory(szBuffer, sizeof(szBuffer));
-    ultostr(InfoObject->ObjectHeader.PointerCount, _strend(szBuffer));
+    i64tostr(InfoObject->ObjectHeader.PointerCount, _strend(szBuffer));
     SetDlgItemText(hwndDlg, ID_OBJECT_REFC, szBuffer);
 
     //Handle Count


### PR DESCRIPTION
`PointerCount` in `OBJECT_HEADER` is actually `LONG_PTR`, not `LONG`. This only makes a difference if you have more than 4 billion references of course. The struct size is unaffected because of padding that was already inserted.

More interestingly I also found that the reference count is being printed as unsigned (I changed this to `i64tostr` to fix both the size and signedness). Now I'm curious if it is theoretically possible to have an object with a negative reference count. As far as I know when the reference count reaches 0 the object manager will delete the object. But there might be edge cases (if the object has `OBJ_PERMANENT`)... who knows.