### PR TITLE
docs: fix simple typo, offfsets -> offsets

### DIFF
--- a/Source/WinObjEx64/kldbg.c
+++ b/Source/WinObjEx64/kldbg.c
@@ -475,7 +475,7 @@ ULONG_PTR ObFindAddress(
 *
 * Purpose:
 *
-* Initialize block offfsets table for working with OBJECT_HEADER data.
+* Initialize block offsets table for working with OBJECT_HEADER data.
 *
 * Note:
 *


### PR DESCRIPTION
There is a small typo in Source/WinObjEx64/kldbg.c.

Should read `offsets` rather than `offfsets`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md