### PR TITLE
Parse extension host callbacks on 24h2 and 25h2

### DIFF
--- a/Source/Shared/ntos/ntbuilds.h
+++ b/Source/Shared/ntos/ntbuilds.h
@@ -91,3 +91,4 @@
 // Windows 11 Active Development Branch
 #define NT_WIN11_DEV            23615 //dev
 #define NT_WIN11_24H2           26020 //canary (24H2)
+#define NT_WIN11_25H2			26080 //canary (25H2)

--- a/Source/Shared/ntos/ntos.h
+++ b/Source/Shared/ntos/ntos.h
@@ -5238,21 +5238,37 @@ typedef VOID(NTAPI* PEX_HOST_NOTIFICATION) (
     _In_ ULONG NotificationType,
     _In_opt_ PVOID Context);
 
-typedef struct _EX_EXTENSION_INFORMATION {
+typedef struct _EX_EXTENSION_INFORMATION_V1 {
     USHORT Id;
     USHORT Version;
     USHORT FunctionCount;
-} EX_EXTENSION_INFORMATION, * PEX_EXTENSION_INFORMATION;
+} EX_EXTENSION_INFORMATION_V1, * PEX_EXTENSION_INFORMATION_V1;
+
+typedef struct _EX_EXTENSION_VERSION {
+    USHORT MajorVersion;
+    USHORT MinorVersion;
+} EX_EXTENSION_VERSION, * PEX_EXTENSION_VERSION;
+
+typedef struct _EX_EXTENSION_INFORMATION_V2 {
+    USHORT Id;
+    EX_EXTENSION_VERSION Version;
+    USHORT FunctionCount;
+} EX_EXTENSION_INFORMATION_V2, * PEX_EXTENSION_INFORMATION_V2;
+
+typedef struct _EX_HOST_TABLE {
+    EX_EXTENSION_INFORMATION_V2 HostInformation;
+    PVOID FunctionTable; //calbacks
+} EX_HOST_TABLE, * PEX_HOST_TABLE;
 
 typedef struct _EX_HOST_PARAMS {
-    EX_EXTENSION_INFORMATION HostInformation;
+    EX_EXTENSION_INFORMATION_V1 HostInformation;
     POOL_TYPE PoolType;
     PVOID HostTable;
     PVOID NotificationRoutine;
     PVOID NotificationContext;
 } EX_HOST_PARAMS, * PEX_HOST_PARAMS;
 
-typedef struct _EX_HOST_ENTRY {
+typedef struct _EX_HOST_ENTRY_V1 {
     LIST_ENTRY ListEntry;
     LONG RefCounter;
     EX_HOST_PARAMS HostParameters;
@@ -5260,10 +5276,29 @@ typedef struct _EX_HOST_ENTRY {
     EX_PUSH_LOCK PushLock;
     PVOID FunctionTable; //callbacks
     ULONG Flags;
-} EX_HOST_ENTRY, * PEX_HOST_ENTRY;
+} EX_HOST_ENTRY_V1, * PEX_HOST_ENTRY_V1;
+
+typedef struct _EX_HOST_ENTRY_V2 {
+    LIST_ENTRY ListEntry;
+    EX_EXTENSION_INFORMATION_V2 HostInformation;
+    ULONG64 RefCounter;
+    EX_PUSH_LOCK PushLock;
+    PEX_HOST_TABLE HostTablesPtr;
+    USHORT HostTablesCount;
+    PEX_HOST_TABLE CurrentHostTableEntry; //only set when an extension registers
+    PVOID NotificationRoutine;
+    PVOID NotificationContext;
+    EX_EXTENSION_VERSION ExtensionVersion;
+    EX_RUNDOWN_REF RundownProtection;
+    PVOID FunctionTable;
+    USHORT ExtensionTableFunctionCount;
+    ULONG Pad;
+    ULONG Flags;
+    EX_HOST_TABLE HostTables[1];
+} EX_HOST_ENTRY_V2, * PEX_HOST_ENTRY_V2;
 
 typedef struct _EX_EXTENSION_REGISTRATION {
-    EX_EXTENSION_INFORMATION Information;
+    EX_EXTENSION_INFORMATION_V1 Information;
     PVOID FunctionTable;
     PVOID* HostTable;
     PDRIVER_OBJECT DriverObject;


### PR DESCRIPTION
# Summary

1. Extension host structures changed in 25H2, and can potentially support more than one host table per host (though right now only one table is used for each host). Adding EX_HOST_ENTRY_V2 and other required structures to correctly parse extension on 25H2.
2. Since 24H2, there is an additional call in ExRegisterExtension that breaks byte pattern search for ExpFindHost. In 25H2. In 25H2, the call from ExRegisterExtension is to a new function ExpFindCompatibleHost, so another search is needed to find ExpFindHost.  The PR fixes the search for both cases.
